### PR TITLE
[semver:minor] [dep + release] Upgrade to datadog-ci v1.16.0, and release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
  - TBD
 
+## [1.3.0] - 2022-10-10
+- Update default datadog-ci version to `1.16.0`.
+
 ## [1.2.0] - 2022-05-19
 - Update default datadog-ci version to `1.7.0`.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For additional options such as customizing the `pollingTimeout` for your CircleC
 | `test_search_query`       | string       | _none_                                    | Trigger tests corresponding to a search query.                                                       |
 | `tunnel`                  | boolean      | `false`                                   | Use the testing tunnel to trigger tests.                                                             |
 | `variables`               | string       | _none_                                    | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.             |
-| `version`                 | string       | `v1.7.0`                                  | The version of `datadog-ci` to use.                                                                  |
+| `version`                 | string       | `v1.16.0`                                 | The version of `datadog-ci` to use.                                                                  |
 
 ## Further Reading
 

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -56,7 +56,7 @@ parameters:
   version:
     type: string
     description: Version of datadog-ci.
-    default: "v1.7.0"
+    default: "v1.16.0"
 steps:
   - run:
       environment:

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -16,7 +16,7 @@ setup() {
     export PARAM_SUBDOMAIN="app1"
     export PARAM_TEST_SEARCH_QUERY="apm"
     export PARAM_TUNNEL="1"
-    export PARAM_VERSION="v1.7.0"
+    export PARAM_VERSION="v1.16.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)
@@ -41,7 +41,7 @@ setup() {
     export PARAM_SUBDOMAIN=""
     export PARAM_TEST_SEARCH_QUERY=""
     export PARAM_TUNNEL="0"
-    export PARAM_VERSION="v1.7.0"
+    export PARAM_VERSION="v1.16.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)


### PR DESCRIPTION
Upgrade default version to [datadog-ci v1.16.0](https://github.com/DataDog/datadog-ci/releases/tag/v1.16.0).

No doc change.