### PR TITLE
[semver:patch] Populate correct parameter name for variables

### DIFF
--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -51,7 +51,7 @@ RunTests() {
         variables=$(echo "${PARAM_VARIABLES}" | tr "," "\n")
         for variable in $variables
         do
-            args+=(--variables "${variable}")
+            args+=(--variable "${variable}")
         done
     fi
 

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -17,11 +17,12 @@ setup() {
     export PARAM_TEST_SEARCH_QUERY="apm"
     export PARAM_TUNNEL="1"
     export PARAM_VERSION="v1.16.0"
+    export PARAM_VARIABLES="KEY=value ANOTHER_KEY=another_value"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)
 
-    if ! echo $result | grep -q "synthetics run-tests --failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --public-id jak-not-now --public-id jak-one-mor --search apm"
+    if ! echo $result | grep -q "synthetics run-tests --failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value"
     then
       echo $result
       exit 1


### PR DESCRIPTION
This PR fixes an issue where variables are populated to the datadog-ci with `--variables` instead of `--variable` parameter.

**What's expected**

With the following orb config:

```yaml
jobs:
  e2e-tests:
    docker:
      - image: cimg/base:stable
    steps:
      - synthetics-ci/run-tests:
          test_search_query: 'tag:e2e-tests'
          variables: 'KEY=value'
```

I expect to see:

```
$ datadog-ci synthetics run-tests --variable KEY=value
```

What I get:

```
$ datadog-ci synthetics run-tests --variables KEY=value
```

The error I get:

```
Unknown Syntax Error: Command not found; did you mean one of:

datadog-ci synthetics run-tests [--apiKey #0] [--appKey #0] [--config #0] [--datadogSite #0] [--failOnCriticalErrors] [--failOnMissingTests] [--failOnTimeout] [-f,--files #0] [-j,--jUnitReport #0] [-p,--public-id #0] [-n,--runName #0] [--subdomain] [-s,--search #0] [-t,--tunnel] [-v,--variable #0]
```
