### PR TITLE
[semver:minor] v1.4.0: Update default datadog-ci version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
- - TBD
+## [1.4.0] - 2022-12-12
+### Changed
+  - Update default datadog-ci version to `2.2.0`
 
 ## [1.3.0] - 2022-10-10
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[![CircleCI Build Status](https://circleci.com/gh/DataDog/synthetics-test-automation-circleci-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/DataDog/synthetics-test-automation-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/datadog/synthetics-ci-orb.svg)](https://circleci.com/orbs/registry/orb/datadog/synthetics-ci-orb) [![Apache 2.0 License](https://shields.io/badge/license-Apache--2.0-lightgray)](https://raw.githubusercontent.com/DataDog/synthetics-ci-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI Build Status](https://circleci.com/gh/DataDog/synthetics-test-automation-circleci-orb.svg?style=shield 'CircleCI Build Status')](https://circleci.com/gh/DataDog/synthetics-test-automation-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/datadog/synthetics-ci-orb.svg)](https://circleci.com/orbs/registry/orb/datadog/synthetics-ci-orb) [![Apache 2.0 License](https://shields.io/badge/license-Apache--2.0-lightgray)](https://raw.githubusercontent.com/DataDog/synthetics-ci-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 Run Synthetic tests in your CircleCI pipelines using the Datadog CircleCI orb.
 
@@ -86,6 +86,7 @@ workflows:
     jobs:
       - e2e-tests
 ```
+
 ### Example orb usage using the [Synthetic Testing Tunnel][10]
 
 ```
@@ -138,7 +139,7 @@ For additional options such as customizing the `pollingTimeout` for your CircleC
 | `test_search_query`       | string       | _none_                                    | Trigger tests corresponding to a search query.                                                       |
 | `tunnel`                  | boolean      | `false`                                   | Use the testing tunnel to trigger tests.                                                             |
 | `variables`               | string       | _none_                                    | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.             |
-| `version`                 | string       | `v1.16.0`                                 | The version of `datadog-ci` to use.                                                                  |
+| `version`                 | string       | `v2.2.0`                                  | The version of `datadog-ci` to use.                                                                  |
 
 ## Further reading
 

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -56,7 +56,7 @@ parameters:
   version:
     type: string
     description: Version of datadog-ci.
-    default: "v1.16.0"
+    default: "v2.2.0"
 steps:
   - run:
       environment:

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -16,7 +16,7 @@ setup() {
     export PARAM_SUBDOMAIN="app1"
     export PARAM_TEST_SEARCH_QUERY="apm"
     export PARAM_TUNNEL="1"
-    export PARAM_VERSION="v1.16.0"
+    export PARAM_VERSION="v2.2.0"
     export PARAM_VARIABLES="KEY=value ANOTHER_KEY=another_value"
     export DATADOG_CI_COMMAND="echo"
 
@@ -42,7 +42,7 @@ setup() {
     export PARAM_SUBDOMAIN=""
     export PARAM_TEST_SEARCH_QUERY=""
     export PARAM_TUNNEL="0"
-    export PARAM_VERSION="v1.16.0"
+    export PARAM_VERSION="v2.2.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)


### PR DESCRIPTION
Release v1.4.0:
- Update default datadog-ci version to 2.2.0