### PR TITLE
[semver:minor] Add `junit_report` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ For additional options such as customizing the `pollingTimeout` for your CircleC
 | `fail_on_critical_errors` | boolean      | `false`                                   | Fail if tests were not triggered or results could not be fetched.                                    |
 | `fail_on_timeout`         | boolean      | `true`                                    | Force the CI to fail (or pass) if one of the results exceeds its test timeout.                       |
 | `files`                   | string       | `{,!(node_modules)/**/}*.synthetics.json` | Glob pattern to detect Synthetic tests config files.                                                 |
+| `junit_report`            | string       | _none_                                    | The filename for a JUnit report if you want to generate one.                                         |
 | `locations`               | string       | _values in test config files_             | String of locations separated by semicolons to override the locations where your tests run.          |
 | `public_ids`              | string       | _values in test config files_             | String of public IDs separated by commas for Synthetic tests you want to trigger.                    |
 | `site`                    | string       | `datadoghq.com`                           | The Datadog site to send data to. If the `DD_SITE` environment variable is set, it takes preference. |

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -25,6 +25,10 @@ parameters:
     type: string
     description: Glob pattern to detect Synthetic tests config files.
     default: ""
+  junit_report:
+    type: string
+    description: The filename for a JUnit report if you want to generate one.
+    default: ""
   locations:
     type: string
     description: String of locations separated by semicolons to override the locations where your tests run.
@@ -66,6 +70,7 @@ steps:
         PARAM_FAIL_ON_CRITICAL_ERRORS: <<parameters.fail_on_critical_errors>>
         PARAM_FAIL_ON_TIMEOUT: <<parameters.fail_on_timeout>>
         PARAM_FILES: <<parameters.files>>
+        PARAM_JUNIT_REPORT: <<parameters.junit_report>>
         PARAM_LOCATIONS: <<parameters.locations>>
         PARAM_PUBLIC_IDS: <<parameters.public_ids>>
         PARAM_SITE: <<parameters.site>>

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -2,7 +2,7 @@
 
 This is where any scripts you wish to include in your orb can be kept. This is encouraged to ensure your orb can have all aspects tested, and is easier to author, since we sacrifice most features an editor offers when editing scripts as text in YAML.
 
-As a part of keeping things seperate, it is encouraged to use environment variables to pass through parameters, rather than using the `<< parameter. >>` syntax that CircleCI offers.
+As a part of keeping things separate, it is encouraged to use environment variables to pass through parameters, rather than using the `<< parameter. >>` syntax that CircleCI offers.
 
 # Including Scripts
 

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -37,6 +37,9 @@ RunTests() {
             args+=(--files "${file}")
         done
     fi
+    if [[ -n $PARAM_JUNIT_REPORT ]]; then
+        args+=(--jUnitReport "${PARAM_JUNIT_REPORT}")
+    fi
     if [[ -n $PARAM_PUBLIC_IDS ]]; then
         public_ids=$(echo "${PARAM_PUBLIC_IDS}" | tr "," "\n")
         for public_id in $public_ids

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -55,7 +55,7 @@ fi
 
 ```
 
-We want our script to execute when running in our CI environment or locally, but we don't want to execute our script if we are testing it. In the case of testing, we only want to source the functions within our script, this allows us to mock inputs and test individual functions.
+You want your script to execute when running in your CI environment or locally, but you don't want to execute your script if you are testing it. In the case of testing, you only want to source the functions within your script—this allows you to mock inputs and test individual functions.
 
 **A POSIX Compliant Source Checking Method:**
 

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,6 +1,6 @@
 # tests/
 
-This is where your testing scripts for whichever language is embeded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
+This is where your testing scripts for whichever language is embedded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
 
 ## Run unit tests locally
 
@@ -55,7 +55,7 @@ fi
 
 ```
 
-We want our script to execute when running in our CI environment or locally, but we don't want to execute our script if we are testing it. In the case of testing, we only want to source the functions within our script,t his allows us to mock inputs and test individual functions.
+We want our script to execute when running in our CI environment or locally, but we don't want to execute our script if we are testing it. In the case of testing, we only want to source the functions within our script, this allows us to mock inputs and test individual functions.
 
 **A POSIX Compliant Source Checking Method:**
 

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -10,6 +10,7 @@ setup() {
     export PARAM_CONFIG_PATH="./some/other/path.json"
     export PARAM_FAIL_ON_TIMEOUT="1"
     export PARAM_FILES="test1.json"
+    export PARAM_JUNIT_REPORT="reports/TEST-1.xml"
     export PARAM_LOCATIONS="aws:eu-west-1"
     export PARAM_PUBLIC_IDS="jak-not-now,jak-one-mor"
     export PARAM_SITE="datadoghq.eu"
@@ -22,7 +23,7 @@ setup() {
 
     result=$(RunTests)
 
-    if ! echo $result | grep -q "synthetics run-tests --failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value"
+    if ! echo $result | grep -q "synthetics run-tests --failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --jUnitReport reports/TEST-1.xml --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value"
     then
       echo $result
       exit 1
@@ -36,6 +37,7 @@ setup() {
     export PARAM_FAIL_ON_CRITICAL_ERRORS="0"
     export PARAM_FAIL_ON_TIMEOUT="1"
     export PARAM_FILES=""
+    export PARAM_JUNIT_REPORT=""
     export PARAM_LOCATIONS=""
     export PARAM_PUBLIC_IDS=""
     export PARAM_SITE=""


### PR DESCRIPTION
This PR adds a `junit_report` input, so that you can build a JUnit XML report of the tests that were run.