### PR TITLE
[semver:major] Remove `version` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2023-02-20
+### Added
+  - Add `junit_report` input
+
 ## [1.4.0] - 2022-12-12
 ### Changed
   - Update default datadog-ci version to `2.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-02-27
+### Removed
+  - Remove `version` input
+
 ## [1.5.0] - 2023-02-20
 ### Added
   - Add `junit_report` input

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ For additional options such as customizing the `pollingTimeout` for your CircleC
 | `test_search_query`       | string       | _none_                                    | Trigger tests corresponding to a search query.                                                       |
 | `tunnel`                  | boolean      | `false`                                   | Use the testing tunnel to trigger tests.                                                             |
 | `variables`               | string       | _none_                                    | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.             |
-| `version`                 | string       | `v2.2.0`                                  | The version of `datadog-ci` to use.                                                                  |
 
 ## Further reading
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,15 +1,15 @@
 version: 2.1
 
 description: >
-  The CircleCI command orb installs datadog-ci and uses the `datadog-ci synthetics run-tests` command to execute DataDog Synthetics tests.
+  The CircleCI command orb installs datadog-ci and uses the `datadog-ci synthetics run-tests` command to execute Datadog Synthetics tests.
 # What will your orb allow users to accomplish?
 # Descriptions should be short, simple, and informative.
-
-# This information will be displayed in the orb registry and is not mandatory.
-display:
-  home_url: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/synthetics"
-  source_url: "https://www.github.com/DataDog/synthetics-ci-orb"
 
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 # orbs:
 #  hello: circleci/hello-build@0.0.5
+
+# This information will be displayed in the orb registry and is not mandatory.
+display:
+  home_url: 'https://github.com/DataDog/datadog-ci/tree/master/src/commands/synthetics'
+  source_url: 'https://www.github.com/DataDog/synthetics-ci-orb'

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -57,10 +57,6 @@ parameters:
     type: string
     description: Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.
     default: ''
-  version:
-    type: string
-    description: Version of datadog-ci.
-    default: 'v2.2.0'
 steps:
   - run:
       environment:
@@ -78,6 +74,5 @@ steps:
         PARAM_TEST_SEARCH_QUERY: <<parameters.test_search_query>>
         PARAM_TUNNEL: <<parameters.tunnel>>
         PARAM_VARIABLES: <<parameters.variables>>
-        PARAM_VERSION: <<parameters.version>>
       name: Run Datadog Synthetics tests
       command: <<include(scripts/run-tests.sh)>>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -12,7 +12,7 @@ parameters:
   config_path:
     type: string
     description: The global JSON configuration used when launching tests.
-    default: ""
+    default: ''
   fail_on_critical_errors:
     type: boolean
     description: Fail if tests were not triggered or results could not be fetched.
@@ -24,31 +24,31 @@ parameters:
   files:
     type: string
     description: Glob pattern to detect Synthetic tests config files.
-    default: ""
+    default: ''
   junit_report:
     type: string
     description: The filename for a JUnit report if you want to generate one.
-    default: ""
+    default: ''
   locations:
     type: string
     description: String of locations separated by semicolons to override the locations where your tests run.
-    default: ""
+    default: ''
   public_ids:
     type: string
     description: String of public IDs separated by commas for Synthetic tests you want to trigger.
-    default: ""
+    default: ''
   site:
     type: string
     description: The Datadog site to send data to. If the `DD_SITE` environment variable is set, it takes preference.
-    default: "datadoghq.com"
+    default: 'datadoghq.com'
   subdomain:
     type: string
     description: The name of the custom subdomain set to access your Datadog application.
-    default: "app"
+    default: 'app'
   test_search_query:
     type: string
     description: Trigger tests corresponding to a search query.
-    default: ""
+    default: ''
   tunnel:
     type: boolean
     description: Use the testing tunnel to trigger tests.
@@ -56,11 +56,11 @@ parameters:
   variables:
     type: string
     description: Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.
-    default: ""
+    default: ''
   version:
     type: string
     description: Version of datadog-ci.
-    default: "v2.2.0"
+    default: 'v2.2.0'
 steps:
   - run:
       environment:

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -6,7 +6,8 @@ RunTests() {
         PARAM_SITE=${DD_SITE}
     fi
 
-    curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/${PARAM_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
+    DATADOG_CI_VERSION=v2.5.1
+    curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
 
     chmod +x ./datadog-ci
 

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -17,7 +17,6 @@ setup() {
     export PARAM_SUBDOMAIN="app1"
     export PARAM_TEST_SEARCH_QUERY="apm"
     export PARAM_TUNNEL="1"
-    export PARAM_VERSION="v2.2.0"
     export PARAM_VARIABLES="KEY=value ANOTHER_KEY=another_value"
     export DATADOG_CI_COMMAND="echo"
 
@@ -44,7 +43,6 @@ setup() {
     export PARAM_SUBDOMAIN=""
     export PARAM_TEST_SEARCH_QUERY=""
     export PARAM_TUNNEL="0"
-    export PARAM_VERSION="v2.2.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)


### PR DESCRIPTION
This PR aims to lock the datadog-ci version in all our CI integrations.

Usually, it's done through the `yarn.lock` file, but in this integration's case, we'll have to remove the `version` input.

