### PR TITLE
[ci] Disable PR comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
           orb-name: datadog/synthetics-ci-orb
           vcs-type: << pipeline.project.type >>
           context: orb-publishing # A restricted context containing private publishing credentials. Will only execute if approved by an authorized user.
+          enable-pr-comment: false
           requires:
             - orb-tools/lint
             - orb-tools/pack

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - synthetics-ci-orb/run-tests:
           fail_on_critical_errors: true
-          files: "ci/file with space.json"
+          files: 'ci/file with space.json'
   integration-test-with-multiple-public-ids:
     docker:
       - image: cimg/base:stable
@@ -51,6 +51,7 @@ workflows:
           vcs-type: << pipeline.project.type >>
           context: orb-publishing # A restricted context containing private publishing credentials. Will only execute if approved by an authorized user.
           pub-type: production
+          enable-pr-comment: false
           requires:
             - integration-test-simple
             - integration-test-with-spaces


### PR DESCRIPTION
I forgot to prevent the `orb-tools/publish` job to comment on PRs.

Nothing bad since this error is non-blocking, but it's still better to disable this.

Failing job: https://app.circleci.com/pipelines/github/DataDog/synthetics-test-automation-circleci-orb/285/workflows/cd21de5b-7279-4c6d-9f13-ed796345b406/jobs/1234/parallel-runs/0/steps/0-103