### PR TITLE
[dep] Upgrade datadog-ci to 2.10.0

### DIFF
--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -6,7 +6,7 @@ RunTests() {
         PARAM_SITE=${DD_SITE}
     fi
 
-    DATADOG_CI_VERSION=v2.5.1
+    DATADOG_CI_VERSION=v2.10.0
     curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
 
     chmod +x ./datadog-ci


### PR DESCRIPTION
Notable change that will be included: https://github.com/DataDog/datadog-ci/pull/831