### PR TITLE
[ci] Fix release version workflow

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -43,13 +43,13 @@ jobs:
         id: bump-version
         run: |
           OLD_VERSION_TAG=$(git describe --abbrev=0 --tags) # e.g. v1.0.0
-          OLD_VERSION=${OLD_VERSION/v/}
+          OLD_VERSION=${OLD_VERSION_TAG/v/}
 
           NEW_VERSION=$(./ci/increment-version.sh ${{ github.event.inputs.semver }})
           NEW_VERSION_TAG="v$NEW_VERSION" # e.g. v1.1.0
 
           # Update README with new version
-          sed -i -E "s/$OLD_VERSION/$NEW_VERSION/" {README.md,src/examples/*.yml}
+          sed -i "s/$OLD_VERSION/$NEW_VERSION/" {README.md,src/examples/*.yml}
 
           echo "NEW_VERSION_TAG=$NEW_VERSION_TAG" >> $GITHUB_OUTPUT
       - name: Commit new version

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Your workflow can be [simple](#simple-usage) or [complex](#complex-usage).
 version: 2.1
 
 orbs:
-  synthetics-ci: datadog/synthetics-ci-orb@1.0.1
+  synthetics-ci: datadog/synthetics-ci-orb@2.1.0
 
 jobs:
   e2e-tests:
@@ -50,7 +50,7 @@ This orb overrides the path to the pattern for [test files][18].
 version: 2.1
 
 orbs:
-  synthetics-ci: datadog/synthetics-ci-orb@1.0.1
+  synthetics-ci: datadog/synthetics-ci-orb@2.1.0
 
 jobs:
   e2e-tests:
@@ -76,7 +76,7 @@ For another example pipeline that triggers Synthetic tests, see the [`simple-exa
 version: 2.1
 
 orbs:
-  synthetics-ci: datadog/synthetics-ci-orb@1.0.1
+  synthetics-ci: datadog/synthetics-ci-orb@2.1.0
 
 jobs:
   e2e-tests:
@@ -98,7 +98,7 @@ workflows:
 version: 2.1
 
 orbs:
-  synthetics-ci: datadog/synthetics-ci-orb@1.0.1
+  synthetics-ci: datadog/synthetics-ci-orb@2.1.0
 
 jobs:
   e2e-tests:
@@ -131,22 +131,22 @@ For additional options such as customizing the `pollingTimeout` for your CircleC
 
 To customize your workflow, you can set the following parameters in a [`run-tests.yml` file][14]:
 
-| Name                      | Type         | Default                                   | Description                                                                                          |
-| ------------------------- | ------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `api_key`                 | env var name | `DATADOG_API_KEY`                         | The name of the environment variable containing the API key.                                         |
-| `api_key`                 | env var name | `DATADOG_APP_KEY`                         | The name of the environment variable containing the app key.                                         |
-| `config_path`             | string       | `datadog-ci.json`                         | The global JSON configuration used when launching tests.                                             |
-| `fail_on_critical_errors` | boolean      | `false`                                   | Fail if tests were not triggered or results could not be fetched.                                    |
-| `fail_on_timeout`         | boolean      | `true`                                    | Force the CI to fail (or pass) if one of the results exceeds its test timeout.                       |
-| `files`                   | string       | `{,!(node_modules)/**/}*.synthetics.json` | Glob pattern to detect Synthetic tests config files.                                                 |
-| `junit_report`            | string       | _none_                                    | The filename for a JUnit report if you want to generate one.                                         |
-| `locations`               | string       | _values in test config files_             | String of locations separated by semicolons to override the locations where your tests run.          |
-| `public_ids`              | string       | _values in test config files_             | String of public IDs separated by commas for Synthetic tests you want to trigger.                    |
+| Name                      | Type         | Default                                   | Description                                                                                                |
+| ------------------------- | ------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `api_key`                 | env var name | `DATADOG_API_KEY`                         | The name of the environment variable containing the API key.                                               |
+| `api_key`                 | env var name | `DATADOG_APP_KEY`                         | The name of the environment variable containing the app key.                                               |
+| `config_path`             | string       | `datadog-ci.json`                         | The global JSON configuration used when launching tests.                                                   |
+| `fail_on_critical_errors` | boolean      | `false`                                   | Fail if tests were not triggered or results could not be fetched.                                          |
+| `fail_on_timeout`         | boolean      | `true`                                    | Force the CI to fail (or pass) if one of the results exceeds its test timeout.                             |
+| `files`                   | string       | `{,!(node_modules)/**/}*.synthetics.json` | Glob pattern to detect Synthetic tests config files.                                                       |
+| `junit_report`            | string       | _none_                                    | The filename for a JUnit report if you want to generate one.                                               |
+| `locations`               | string       | _values in test config files_             | String of locations separated by semicolons to override the locations where your tests run.                |
+| `public_ids`              | string       | _values in test config files_             | String of public IDs separated by commas for Synthetic tests you want to trigger.                          |
 | `site`                    | string       | `datadoghq.com`                           | The [Datadog site][17] to send data to. If the `DD_SITE` environment variable is set, it takes preference. |
-| `subdomain`               | string       | `app`                                     | The name of the custom subdomain set to access your Datadog application.                             |
-| `test_search_query`       | string       | _none_                                    | Trigger tests corresponding to a search query.                                                       |
-| `tunnel`                  | boolean      | `false`                                   | Use the Continuous Testing Tunnel to trigger tests.                                                             |
-| `variables`               | string       | _none_                                    | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.             |
+| `subdomain`               | string       | `app`                                     | The name of the custom subdomain set to access your Datadog application.                                   |
+| `test_search_query`       | string       | _none_                                    | Trigger tests corresponding to a search query.                                                             |
+| `tunnel`                  | boolean      | `false`                                   | Use the Continuous Testing Tunnel to trigger tests.                                                        |
+| `variables`               | string       | _none_                                    | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.                   |
 
 To customize parameters such as `pollingTimeout` and learn about additional options for your CircleCI pipelines, see [Continuous Testing & CI/CD Integrations Configuration][12].
 

--- a/src/examples/advanced-example.yml
+++ b/src/examples/advanced-example.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
 
   orbs:
-    synthetics-ci: datadog/synthetics-ci-orb@1.0.1
+    synthetics-ci: datadog/synthetics-ci-orb@2.1.0
 
   jobs:
     integration-tests:

--- a/src/examples/simple-example.yml
+++ b/src/examples/simple-example.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    synthetics-ci-orb: datadog/synthetics-ci-orb@1.0.1
+    synthetics-ci-orb: datadog/synthetics-ci-orb@2.1.0
   workflows:
     test:
       jobs:


### PR DESCRIPTION
This PR fixes this issue: https://github.com/DataDog/synthetics-test-automation-circleci-orb/actions/runs/5047132225/jobs/9053562467

And it updates the outdated documents that are meant to be updated by this exact workflow. Since the workflow looks for the previous version, the previous version **has to be present**. Otherwise, the substitution of the old version with the new version will fail.