### PR TITLE
[test] Use `diff` in bats tests

### DIFF
--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -22,13 +22,7 @@ setup() {
     export PARAM_VARIABLES="KEY=value ANOTHER_KEY=another_value"
     export DATADOG_CI_COMMAND="echo"
 
-    result=$(RunTests)
-
-    if ! echo $result | grep -q "synthetics run-tests --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --jUnitReport reports/TEST-1.xml --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value"
-    then
-      echo $result
-      exit 1
-    fi
+    diff <(RunTests) <(echo "synthetics run-tests --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --jUnitReport reports/TEST-1.xml --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value")
 }
 
 @test 'Use default parameters' {
@@ -50,9 +44,5 @@ setup() {
 
     result=$(RunTests)
 
-    if ! echo $result | grep -q "synthetics run-tests --failOnTimeout"
-    then
-      echo $result
-      exit 1
-    fi
+    diff <(RunTests) <(echo "synthetics run-tests --failOnTimeout")
 }


### PR DESCRIPTION
- #40 ←
- #41
---

It was not obvious what was missing in the output of the tests. Now with the `diff` program, we have the difference between what's expected and the actual command.

**Before:**

![image](https://github.com/DataDog/synthetics-test-automation-circleci-orb/assets/9317502/ad38d019-71d2-4af5-8ef6-6e4d5bfd5f9f)

**After:**

![image](https://github.com/DataDog/synthetics-test-automation-circleci-orb/assets/9317502/845f5617-0984-4d67-bd38-161f0d2ddf64)

> **Warning**: do not get fooled by the exit codes in the screenshot! The ones you see are the exit codes **for the previous commands**.