### PR TITLE
[e2e] Replace public IDs for integration tests

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - checkout
       - synthetics-ci-orb/run-tests:
+          config_path: ci/global.config.json
           fail_on_critical_errors: true
           public_ids: pwd-mwg-3p5, 2r9-q7u-4nn
 

--- a/ci/global.config.json
+++ b/ci/global.config.json
@@ -1,0 +1,8 @@
+{
+  "global": {
+    "headers": {
+      "X-Fake-Header": "fake value"
+    },
+    "pollingTimeout": 240000
+  }
+}


### PR DESCRIPTION
The `6jq-89z-5ur` public ID doesn't exist anymore, and let's use the same public IDs as the other CI integrations for e2e tests.