### PR TITLE
[noop] Small improvements

### DIFF
--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -7,12 +7,12 @@ RunTests() {
     fi
 
     DATADOG_CI_VERSION="2.20.0"
-    curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
 
-    chmod +x ./datadog-ci
-
-    # Only used for unit test purposes
+    # Not run when running unit tests.
     if [[ -z "${DATADOG_CI_COMMAND}" ]]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
+        chmod +x ./datadog-ci
+
         DATADOG_CI_COMMAND="./datadog-ci"
     fi
 
@@ -36,8 +36,7 @@ RunTests() {
     fi
     if [[ -n $PARAM_FILES ]]; then
         files=$(echo "${PARAM_FILES}" | tr "," "\n")
-        for file in $files
-        do
+        for file in $files; do
             args+=(--files "${file}")
         done
     fi
@@ -49,8 +48,7 @@ RunTests() {
     fi
     if [[ -n $PARAM_PUBLIC_IDS ]]; then
         public_ids=$(echo "${PARAM_PUBLIC_IDS}" | tr "," "\n")
-        for public_id in $public_ids
-        do
+        for public_id in $public_ids; do
             args+=(--public-id "${public_id}")
         done
     fi
@@ -59,8 +57,7 @@ RunTests() {
     fi
     if [[ -n $PARAM_VARIABLES ]]; then
         variables=$(echo "${PARAM_VARIABLES}" | tr "," "\n")
-        for variable in $variables
-        do
+        for variable in $variables; do
             args+=(--variable "${variable}")
         done
     fi

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -4,6 +4,8 @@ setup() {
     source ./src/scripts/run-tests.sh
 }
 
+DIFF_ARGS="-u --label actual --label expected"
+
 @test 'Use custom parameters' {
     export PARAM_API_KEY="DD_API_KEY"
     export PARAM_APP_KEY="DD_APP_KEY"
@@ -23,7 +25,7 @@ setup() {
     export PARAM_VARIABLES="KEY=value ANOTHER_KEY=another_value"
     export DATADOG_CI_COMMAND="echo"
 
-    diff <(RunTests) <(echo "synthetics run-tests --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --jUnitReport reports/TEST-1.xml --pollingTimeout 123 --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value")
+    diff $DIFF_ARGS <(RunTests) <(echo synthetics run-tests --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --jUnitReport reports/TEST-1.xml --pollingTimeout 123 --public-id jak-not-now --public-id jak-one-mor --search apm --variable KEY=value --variable ANOTHER_KEY=another_value)
 }
 
 @test 'Use default parameters' {
@@ -46,5 +48,5 @@ setup() {
 
     result=$(RunTests)
 
-    diff <(RunTests) <(echo "synthetics run-tests --failOnTimeout")
+    diff $DIFF_ARGS <(RunTests) <(echo synthetics run-tests --failOnTimeout)
 }


### PR DESCRIPTION
- https://github.com/DataDog/synthetics-test-automation-circleci-orb/pull/68 ←
- https://github.com/DataDog/synthetics-test-automation-circleci-orb/pull/69
---

This PR contains improvements on the unit testing environment and a syntax nit.

- Do not download the CLI with `curl` in unit tests, this is already done in e2e/integration tests
- Put `for` and `do` on one line
- Put `expected` and `actual` labels in unit test diffs (see before/after below)
- Do not surround the list of CLI arguments in double quotes, as it differs from the behavior with `datadog-ci` - the actual CLI. In unit tests, we replace `datadog-ci` with `echo`, and we want to exactly compare the 2 command lines.
  - Without this, https://github.com/DataDog/synthetics-test-automation-circleci-orb/pull/69 cannot do `diff $DIFF_ARGS <(RunTests) <(echo synthetics run-tests --no-failOnTimeout --files "ci/file with space.json")`
---
**Before:**
![image](https://github.com/DataDog/synthetics-test-automation-circleci-orb/assets/9317502/c9d77076-ffa2-4c1d-a307-3ffb9d85ec84)

**After:**
![image](https://github.com/DataDog/synthetics-test-automation-circleci-orb/assets/9317502/dd2ab0bb-e4bc-4c6b-b988-70cf3404e820)
