### PR TITLE
Replace `pollingTimeout` input by `batchTimeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ workflows:
             - build-image
 ```
 
-For additional options such as customizing the `pollingTimeout` for your CircleCI pipelines, see [CI/CD Integrations Configuration][18]. For another example pipeline that starts a local server and triggers Synthetic tests using the Continuous Testing Tunnel, see the [`advanced-example.yml` file][16].
+For additional options such as customizing the `batchTimeout` for your CircleCI pipelines, see [CI/CD Integrations Configuration][18]. For another example pipeline that starts a local server and triggers Synthetic tests using the Continuous Testing Tunnel, see the [`advanced-example.yml` file][16].
 
 ## Inputs
 
@@ -145,7 +145,6 @@ To customize your workflow, you can set the following parameters in a [`run-test
 | `junit_report`            | string       | _none_                                    | The filename for a JUnit report if you want to generate one.                                                                                                                                                            |
 | `locations`               | string       | _values in [test files][18]_              | String of locations separated by semicolons to override the locations where your tests run.                                                                                                                             |
 | `no_output_timeout`       | string       | _30 minutes_                              | Elapsed time the command can run without output. The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”. [See official CircleCI documentation](https://circleci.com/docs/configuration-reference/#run). |
-| `polling_timeout`         | number       | _30 minutes_                              | **DEPRECATED** in favor of batch_timeout. The duration (in milliseconds) after which the action stops polling for test results. At the CI level, test results completed after this duration are considered failed.      |
 | `public_ids`              | string       | _values in [test files][18]_              | A list of test IDs for Synthetic tests you want to trigger, separated by new lines or commas.                                                                                                                           |
 | `site`                    | string       | `datadoghq.com`                           | The [Datadog site][17] to send data to. If the `DD_SITE` environment variable is set, it takes preference.                                                                                                              |
 | `subdomain`               | string       | `app`                                     | The name of the custom subdomain set to access your Datadog application.                                                                                                                                                |

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -49,10 +49,6 @@ parameters:
     type: string
     description: Elapsed time the command can run without output.
     default: '30m'
-  polling_timeout:
-    type: integer
-    description: '**DEPRECATED** The duration (in milliseconds) after which the action stops polling for test results.'
-    default: 1800000
   public_ids:
     type: string
     description: String of public IDs separated by commas for Synthetic tests you want to trigger.

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -44,10 +44,6 @@ RunTests() {
     if [[ -n $PARAM_JUNIT_REPORT ]]; then
         args+=(--jUnitReport "${PARAM_JUNIT_REPORT}")
     fi
-    # TODO SYNTH-12989: Clean up deprecated `--pollingTimeout` in favor of `--batchTimeout`
-    if [[ -n $PARAM_POLLING_TIMEOUT ]]; then
-        args+=(--batchTimeout "${PARAM_POLLING_TIMEOUT}")
-    fi
     if [[ -n $PARAM_PUBLIC_IDS ]]; then
         IFS=$'\n,'
         for public_id in ${PARAM_PUBLIC_IDS}; do

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -17,7 +17,6 @@ DIFF_ARGS="-u --label actual --label expected"
     export PARAM_FILES="test1.json"
     export PARAM_JUNIT_REPORT="reports/TEST-1.xml"
     export PARAM_LOCATIONS="aws:eu-west-1"
-    export PARAM_POLLING_TIMEOUT="123"
     export PARAM_PUBLIC_IDS="jak-not-now,jak-one-mor"
     export PARAM_SITE="datadoghq.eu"
     export PARAM_SUBDOMAIN="app1"
@@ -26,7 +25,7 @@ DIFF_ARGS="-u --label actual --label expected"
     export PARAM_VARIABLES='START_URL=https://example.org,MY_VARIABLE="My title"'
     export DATADOG_CI_COMMAND="echo"
 
-    diff $DIFF_ARGS <(RunTests) <(echo synthetics run-tests --batchTimeout 123 --config ./some/other/path.json --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --files test1.json --jUnitReport reports/TEST-1.xml --batchTimeout 123 --public-id jak-not-now --public-id jak-one-mor --search apm --tunnel --variable START_URL=https://example.org --variable MY_VARIABLE=\"My title\")
+    diff $DIFF_ARGS <(RunTests) <(echo synthetics run-tests --batchTimeout 123 --config ./some/other/path.json --failOnCriticalErrors --failOnMissingTests --no-failOnTimeout --files test1.json --jUnitReport reports/TEST-1.xml --public-id jak-not-now --public-id jak-one-mor --search apm --tunnel --variable START_URL=https://example.org --variable MY_VARIABLE=\"My title\")
 }
 
 @test 'Use default parameters' {
@@ -40,7 +39,6 @@ DIFF_ARGS="-u --label actual --label expected"
     export PARAM_FILES=""
     export PARAM_JUNIT_REPORT=""
     export PARAM_LOCATIONS=""
-    export PARAM_POLLING_TIMEOUT=""
     export PARAM_PUBLIC_IDS=""
     export PARAM_SITE=""
     export PARAM_SUBDOMAIN=""


### PR DESCRIPTION
This PR is a breaking change that removes the `polling_timeout` input in favor of `batch_timeout` to align with the major version of datadog-ci.